### PR TITLE
ランキングページからユーザーのGithubページに遷移するように実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./external_link_warning"

--- a/app/javascript/external_link_warning.js
+++ b/app/javascript/external_link_warning.js
@@ -4,7 +4,7 @@ function externalLinkWarning() {
   externalLinks.forEach(link => {
     link.addEventListener("click", function(event) {
       event.preventDefault();
-      const proceed = confirm("このリンクは外部サイトに遷移します。続行しますか？");
+      const proceed = confirm("このリンクはユーザーのGithubページに遷移します。続行しますか？");
       if (proceed) {
         window.open(link.href, "_blank");
       }

--- a/app/javascript/external_link_warning.js
+++ b/app/javascript/external_link_warning.js
@@ -1,0 +1,15 @@
+function externalLinkWarning() {
+  const externalLinks = document.querySelectorAll('a[data-external-link="true"]');
+
+  externalLinks.forEach(link => {
+    link.addEventListener("click", function(event) {
+      event.preventDefault();
+      const proceed = confirm("このリンクは外部サイトに遷移します。続行しますか？");
+      if (proceed) {
+        window.open(link.href, "_blank");
+      }
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", externalLinkWarning);

--- a/app/views/ranks/_user_contribution_rank.html.erb
+++ b/app/views/ranks/_user_contribution_rank.html.erb
@@ -1,7 +1,11 @@
 <% offset = (@user_contribution_ranks.current_page - 1) * @user_contribution_ranks.limit_value %>
 <tr class="hover">
   <th><%= user_contribution_rank_counter + 1 + offset %> 位</th>
-  <td><%= user_contribution_rank.user.nickname %></td>
+  <td>
+    <%= link_to "https://github.com/#{user_contribution_rank.user.nickname}", target: "_blank", data: { external_link: "true" } , class:"link link-hover" do %>
+      <% user_contribution_rank.user.nickname %>
+    <% end %>
+  </td>
   <% contribution = user_contribution_rank %>
   <% if contribution.present?%>
     <td><%= contribution.contribution_number if contribution.contribution_number.present? %> 草</td>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,10 +28,10 @@
             <li>
               <%= link_to "マイページ", user_path(current_user.id), class:"btn" %>
             </li>
+            <li>
+              <%= link_to "ランキング", ranks_path, class:"btn mt-3" %>
+            </li>
           </div>
-          <li>
-            <%= link_to "ランキング", ranks_path, class:"btn mt-3" %>
-          </li>
           <li>
             <%= link_to "ログアウト", sign_out_path, data:{ turbo_method: :delete }, class:"btn btn-accent mt-3" %>
           </li>


### PR DESCRIPTION
#129 

ランキングのユーザー名をリンクに変更し、外部サイトへ飛べるように実装する